### PR TITLE
DEXW-2722: add <SmartAssetLogo>

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@waves.exchange/react-uikit",
-  "version": "0.3.31",
+  "version": "0.3.32",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@waves.exchange/react-uikit",
-  "version": "0.3.31",
+  "version": "0.3.32",
   "description": "",
   "license": "MIT",
   "main": "dist/cjs/index.js",

--- a/src/components/AssetLogo/AssetLogo.tsx
+++ b/src/components/AssetLogo/AssetLogo.tsx
@@ -21,7 +21,7 @@ import { getAssetLogoBgColor, getHeight, wrapWith } from './helpers';
 import { variants } from './styles';
 import { iconWavesLogo } from '../../icons/waves-logo';
 
-type Props = {
+export type AssetLogoProps = {
     assetId: string | null;
     /**
      * Icon url or base64 icon
@@ -42,7 +42,7 @@ export const AssetLogo = styled(
         (props) => <Icon {...omit(NAMES, props)} icon={iconWavesLogo} />,
         (props) => <Box {...omit(NAMES, props)}></Box>
     )
-)<Props>(
+)<AssetLogoProps>(
     css({
         borderRadius: '100%',
         backgroundSize: '100% 100%',

--- a/src/components/AssetLogo/SmartAssetLogo.tsx
+++ b/src/components/AssetLogo/SmartAssetLogo.tsx
@@ -1,0 +1,105 @@
+import React, { FC, ReactNode } from 'react';
+import { Options } from '@popperjs/core';
+import { AssetLogo, AssetLogoProps } from './AssetLogo';
+import { BoxProps, Box } from '../Box/Box';
+import { Tooltip } from '../Tooltip/Tooltip';
+import { Flex } from '../Flex/Flex';
+import { Icon } from '../Icon/Icon';
+import { Text } from '../Text/Text';
+import { iconSmartMini } from '../../icons/smartMini';
+
+type SmartAssetLogoProps = BoxProps &
+    AssetLogoProps &
+    Record<'popperOptions', Partial<Options>> &
+    Record<'isSmart', boolean>;
+
+export const SmartAssetLogo: FC<SmartAssetLogoProps> = ({
+    assetId,
+    isSmart,
+    name,
+    logo,
+    variant,
+    popperOptions,
+    ...rest
+}) => {
+    return (
+        <Box position="relative" {...rest}>
+            <AssetLogo
+                assetId={assetId}
+                name={name}
+                logo={logo}
+                variant={variant}
+            />
+            {isSmart && (
+                <Tooltip
+                    arrowSize="4px"
+                    hasArrow={true}
+                    arrowColor="#5A81EA" // TODO научить тултип понимать цвета из темы
+                    offset={4}
+                    maxWidth="360px"
+                    label={(): ReactNode => (
+                        <Flex
+                            borderTop="4px solid"
+                            borderTopColor="primary.$300"
+                            backgroundColor="#4a5060"
+                            borderRadius="$4"
+                            py="8px"
+                            px="12px"
+                            color="standard.$0"
+                            width="max-content"
+                            maxWidth="100%"
+                        >
+                            <Flex
+                                alignItems="center"
+                                justifyContent="center"
+                                size="16px"
+                                borderRadius="circle"
+                                backgroundColor="main.$600"
+                                flex="none"
+                            >
+                                <Icon
+                                    icon={iconSmartMini}
+                                    size={10}
+                                    color="standard.$0"
+                                />
+                            </Flex>
+                            <Text ml="$10" variant="body2">
+                                Smart asset
+                            </Text>
+                        </Flex>
+                    )}
+                    placement="bottom"
+                    popperOptions={{
+                        modifiers: [
+                            {
+                                name: 'flip',
+                                enabled: false,
+                            },
+                        ],
+                        strategy: 'fixed',
+                        ...popperOptions,
+                    }}
+                >
+                    <Flex
+                        position="absolute"
+                        bottom={0}
+                        right={0}
+                        width={14}
+                        height={14}
+                        justifyContent="center"
+                        alignItems="center"
+                        borderRadius="circle"
+                        backgroundColor="main.$800"
+                        cursor="pointer"
+                    >
+                        <Icon
+                            icon={iconSmartMini}
+                            size={8}
+                            color="standard.$0"
+                        />
+                    </Flex>
+                </Tooltip>
+            )}
+        </Box>
+    );
+};

--- a/src/hooks/useBoundedTooltip.ts
+++ b/src/hooks/useBoundedTooltip.ts
@@ -1,0 +1,47 @@
+import { useState, useCallback, useEffect } from 'react';
+import { Options } from '@popperjs/core';
+
+type UseBoundedTooltip = (args: {
+    left?: number; // sets padding between padding and boundary edge and the tooltip
+    right?: number;
+}) => {
+    popperOptions: Partial<Options>;
+    boundaryRef: (node: any) => void;
+};
+
+export const useBoundedTooltip: UseBoundedTooltip = ({
+    left = 80,
+    right = 80,
+}) => {
+    const [tooltipBoundingEl, setTooltipBoundingEl] = useState();
+    const [popperOptions, setPopperOptions] = useState({});
+
+    const boundaryRef = useCallback((node) => {
+        if (node !== null) {
+            setTooltipBoundingEl(node);
+        }
+    }, []);
+
+    useEffect(
+        () =>
+            tooltipBoundingEl &&
+            setPopperOptions({
+                modifiers: [
+                    {
+                        name: 'preventOverflow',
+                        enabled: true,
+                        options: {
+                            boundary: tooltipBoundingEl,
+                            padding: { left, right },
+                        },
+                    },
+                ],
+            }),
+        [left, right, tooltipBoundingEl]
+    );
+
+    return {
+        boundaryRef,
+        popperOptions,
+    };
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 export * from './components/AssetLogo/AssetLogo';
+export * from './components/AssetLogo/SmartAssetLogo';
 export * from './components/Avatar/Avatar';
 export * from './components/AddressAvatar/AddressAvatar';
 export * from './components/Box/Box';
@@ -69,3 +70,5 @@ export * from './icons/wavesKeeperMini';
 export * from './icons/smartMini';
 //types
 export * from './interface';
+//hooks
+export * from './hooks/useBoundedTooltip';


### PR DESCRIPTION
Фикс для пункта
- Не отображается признак скриптованности в иконке (test-scripted)
в задаче  [2722](https://jira.wavesplatform.com/browse/DEXW-2722?focusedCommentId=71880&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-71880)

Добавлен hook `useBoundedTooltip` для того, чтобы ограничивать тултип областью некоторого html элемента. Пример использования можно увидеть [здесь](https://github.com/waves-exchange/provider-web/pull/20/files)